### PR TITLE
Avoid UTF-8 data corruption

### DIFF
--- a/lib/Mojo/RabbitMQ/Client.pm
+++ b/lib/Mojo/RabbitMQ/Client.pm
@@ -454,6 +454,7 @@ sub _write {
   my $id    = shift @_;
   my $frame = shift @_;
 
+  utf8::downgrade($frame);
   $self->_loop->stream($id)->write($frame)
     if defined $self->_loop->stream($id);
 }


### PR DESCRIPTION
syswrite on SSL sockets will corrupt the frames as it interpretes them
as UTF-8 strings. So remove the utf-8 flag