### PR TITLE
Virtualhost other than / was not accepted by RabbitMQ

### DIFF
--- a/lib/Mojo/RabbitMQ/Client.pm
+++ b/lib/Mojo/RabbitMQ/Client.pm
@@ -355,9 +355,18 @@ sub _tune {
         }
       ) if $heartbeat;
 
+      # virtual host is in URL after the last /
+      # amqp://myuser:mypassword@ipadress:5672/myvirtualhostname
+      my $virtual_host = $self->url->path;
+      # The virtualhostname must be _without_ a / in the beginning
+      # in RabbitMQ 3.3.5. A virtual host with starting / receives a "connection refused"
+      if ($virtual_host ne '/') {
+        $virtual_host =~ s#^/##;
+      }
+
       $self->_write_expect(
         'Connection::Open' =>
-          {virtual_host => $self->url->path, capabilities => '', insist => 1,},
+          {virtual_host => $virtual_host, capabilities => '', insist => 1,},
         'Connection::OpenOk' => sub {
           $self->is_open(1);
           $self->emit('open');


### PR DESCRIPTION
When having a virtual host other than /  the method connect does not work. I get an errormessage 

{handshake_error,opening,0,
                 {amqp_error,access_refused,
                             "access to vhost '/myvirtualhost' refused for user 'myuser'",
                             'connection.open'}}

The vhost '/myvirtualhost' should be 'virtualhost' without the leading slash.