### PR TITLE
Changing to use of 'use' to avoid circular includes / redefines

### DIFF
--- a/lib/Mojo/RabbitMQ/Client.pm
+++ b/lib/Mojo/RabbitMQ/Client.pm
@@ -16,9 +16,9 @@ use Net::AMQP;
 use Net::AMQP::Common qw(:all);
 
 use Mojo::RabbitMQ::Client::Channel;
-use Mojo::RabbitMQ::Client::Consumer;
 use Mojo::RabbitMQ::Client::LocalQueue;
-use Mojo::RabbitMQ::Client::Publisher;
+require Mojo::RabbitMQ::Client::Consumer;
+require Mojo::RabbitMQ::Client::Publisher;
 
 our $VERSION = "0.0.9";
 

--- a/lib/Mojo/RabbitMQ/Client/Consumer.pm
+++ b/lib/Mojo/RabbitMQ/Client/Consumer.pm
@@ -1,6 +1,6 @@
 package Mojo::RabbitMQ::Client::Consumer;
 use Mojo::Base 'Mojo::EventEmitter';
-use Mojo::RabbitMQ::Client;
+require Mojo::RabbitMQ::Client;
 
 has url      => undef;
 has client   => undef;

--- a/lib/Mojo/RabbitMQ/Client/Publisher.pm
+++ b/lib/Mojo/RabbitMQ/Client/Publisher.pm
@@ -1,8 +1,8 @@
 package Mojo::RabbitMQ::Client::Publisher;
 use Mojo::Base -base;
 use Mojo::Promise;
-use Mojo::RabbitMQ::Client;
 use Mojo::JSON qw(encode_json);
+require Mojo::RabbitMQ::Client;
 
 use constant DEBUG => $ENV{MOJO_RABBITMQ_DEBUG} // 0;
 


### PR DESCRIPTION
Should be able to close inway/mojo-rabbitmq-client#20 after applying this patch.

Same command run as mentioned in the issue:

```bash
for file in $( find lib/ -type f ); do perl -Ilib -c $file; done
lib/Mojo/RabbitMQ/Client.pm syntax OK
lib/Mojo/RabbitMQ/Client/Method.pm syntax OK
lib/Mojo/RabbitMQ/Client/Method/Publish.pm syntax OK
lib/Mojo/RabbitMQ/Client/Publisher.pm syntax OK
lib/Mojo/RabbitMQ/Client/Consumer.pm syntax OK
lib/Mojo/RabbitMQ/Client/LocalQueue.pm syntax OK
lib/Mojo/RabbitMQ/Client/Channel.pm syntax OK
```

Tests have also been run without incident.