### PR TITLE
fix POD syntax error

### DIFF
--- a/lib/Mojo/RabbitMQ/Client/Publisher.pm
+++ b/lib/Mojo/RabbitMQ/Client/Publisher.pm
@@ -199,6 +199,8 @@ But beware - headers get merged, but params override values so when you write th
 
 message will lack C<content_type> header!
 
+=back
+
 =head1 SEE ALSO
 
 L<Mojo::RabbitMQ::Client>


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Mojo-RabbitMQ-Client.
We thought you might be interested in it too.

    Description: fix POD syntax error:
     Hey! The above document had some coding errors, which are explained
     below:
     .
     Around line 202:
         You forgot a '=back' before '=head1'
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2018-07-29
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libmojo-rabbitmq-client-perl/raw/master/debian/patches/pod-syntax.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
