### PR TITLE
fix a spelling and a grammar bug

### DIFF
--- a/lib/Mojo/RabbitMQ/Client/Channel.pm
+++ b/lib/Mojo/RabbitMQ/Client/Channel.pm
@@ -656,7 +656,7 @@ Mojo::RabbitMQ::Client::Channel - handles all channel related methods
 
   my $channel = Mojo::RabbitMQ::Client::Channel->new();
 
-  $channel->catch(sub { warn "Some channel error occured: " . $_[1] });
+  $channel->catch(sub { warn "Some channel error occurred: " . $_[1] });
 
   $channel->on(
     open => sub {
@@ -670,7 +670,7 @@ Mojo::RabbitMQ::Client::Channel - handles all channel related methods
 
 =head1 DESCRIPTION
 
-L<Mojo::RabbitMQ::Client::Channel> allows to call all channel related methods.
+L<Mojo::RabbitMQ::Client::Channel> allows one to call all channel related methods.
 
 =head1 EVENTS
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Mojo-RabbitMQ-Client.
We thought you might be interested in it too.

    Description: fix a spelling and a grammar bug
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2018-07-29
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libmojo-rabbitmq-client-perl/raw/master/debian/patches/spelling.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
