### PR TITLE
Prevent warning about undefined object on closed channels

### DIFF
--- a/lib/Mojo/RabbitMQ/Client.pm
+++ b/lib/Mojo/RabbitMQ/Client.pm
@@ -351,9 +351,9 @@ sub _connect {
 
       # Connection established
       $stream->on(timeout => sub { $self->_error($id, 'Inactivity timeout') });
-      $stream->on(close => sub { $self->_handle($id, 1) });
+      $stream->on(close => sub { $self && $self->_handle($id, 1) });
       $stream->on(error => sub { $self && $self->_error($id, pop) });
-      $stream->on(read => sub { $self->_read($id, pop) });
+      $stream->on(read => sub { $self && $self->_read($id, pop) });
       $cb->();
     }
   );


### PR DESCRIPTION
This prevents warnings like

```
(in cleanup) Can't call method "_handle" on an undefined value at /usr/lib/perl5/vendor_perl/5.18.2/Mojo/RabbitMQ/Client.pm line 354.
```

as reported in https://github.com/inway/mojo-rabbitmq-client/issues/30